### PR TITLE
Add missing working-directory to create correctly expected folders

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure storage and cache directories are writable
+        working-directory: backend
         run: |
           mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views bootstrap/cache
           chmod -R ug+rwx storage bootstrap/cache


### PR DESCRIPTION
All is in the title

Ensure folders will be created in the backend folder as expected