### PR TITLE
Add links to legal pages in api

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -19,6 +19,7 @@
 /storage/*.key
 /storage/pail
 /vendor
+package-lock.json
 Homestead.json
 Homestead.yaml
 Thumbs.db

--- a/backend/app/Http/Controllers/HealthController.php
+++ b/backend/app/Http/Controllers/HealthController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Health\HealthChecker;
+use Illuminate\Foundation\Events\DiagnosingHealth;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 
 final class HealthController
 {
@@ -19,5 +22,24 @@ final class HealthController
             ['ok' => false, 'message' => $result['message'] ?? 'Unhealthy'],
             503
         );
+    }
+
+    public static function checkApi(): View
+    {
+        $exception = null;
+
+        try {
+            Event::dispatch(new DiagnosingHealth);
+        } catch (\Throwable $e) {
+            report($e);
+            $exception = $e->getMessage();
+        }
+
+        return view('home', [
+            'copyrightStartYear' => '2025',
+            'copyrightEndYear' => date('Y'),
+            'healthy' => $exception === null,
+            'healthMessage' => $exception,
+        ]);
     }
 }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -21,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Event::listen(DiagnosingHealth::class, SimulateAppDown::class);
     }
 }

--- a/backend/config/job.php
+++ b/backend/config/job.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'legal_notice_url' => env('LEGAL_NOTICE_URL', 'https://job.manooweb.fr/legal-notice'),
+    'privacy_policy_url' => env('PRIVACY_POLICY_URL', 'https://job.manooweb.fr/privacy-policy'),
+];

--- a/backend/lang/fr/home.php
+++ b/backend/lang/fr/home.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'title' => 'Application Tracker API',
+    'status_label' => "Statut de l'API",
+    'status_up' => 'EN LIGNE',
+    'status_down' => 'HORS LIGNE',
+    'legal_notice' => 'Mentions légales',
+    'privacy_policy' => 'Politique de confidentialité',
+];

--- a/backend/public/css/home.css
+++ b/backend/public/css/home.css
@@ -1,0 +1,51 @@
+.main h1 a {
+  color: #000;
+  text-decoration: none;
+}
+
+.app-container {
+  padding: 16px;
+}
+
+.active-link {
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+/* Footer */
+.app-footer {
+  margin-top: 32px;
+  background: rgba(17, 24, 39, 0.04); // léger contraste
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.app-footer__inner {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 14px 16px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.app-footer__links {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.app-footer a {
+  color: #0f766e;
+  text-decoration: none;
+}
+
+.app-footer a:hover,
+.app-footer a:focus-visible {
+  text-decoration: underline;
+}
+
+.app-footer__muted {
+  color: rgba(17, 24, 39, 0.65);
+  font-size: 14px;
+}

--- a/backend/public/js/matomo-api.js
+++ b/backend/public/js/matomo-api.js
@@ -1,0 +1,17 @@
+var _paq = (window._paq = window._paq || []);
+_paq.push(['disableCookies']);
+_paq.push(['setDoNotTrack', true]);
+_paq.push(['enableLinkTracking']);
+_paq.push(['HeatmapSessionRecording::disable']);
+_paq.push(['trackPageView']);
+(function () {
+    var u = 'https://stats.manooweb.fr/';
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '5']);
+    var d = document,
+        g = d.createElement('script'),
+        s = d.getElementsByTagName('script')[0];
+    g.async = true;
+    g.src = u + 'matomo.js';
+    s.parentNode.insertBefore(g, s);
+})();

--- a/backend/resources/views/home.blade.php
+++ b/backend/resources/views/home.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>{{ __('home.title') }}</title>
+
+    <link rel="stylesheet" href="{{ asset('css/home.css') }}">
+</head>
+
+<body>
+    <main class="main">
+        <h1><a href="/">{{ __('home.title') }}</a></h1>
+    </main>
+
+    <div class="app-container">
+        <p>{{ __('home.status_label') }}: <strong>
+        @if ($healthy)
+            {{ __('home.status_up') }} ✅
+        @else
+            {{ __('home.status_down') }} ❌
+        @endif
+        </strong></p>
+    </div>
+    <footer class="app-footer">
+        <div class="app-footer__inner">
+            <span class="app-footer__muted">
+                © {{ $copyrightStartYear }} - {{ $copyrightEndYear }} Manooweb
+            </span>
+            <nav class="app-footer__links" aria-label="Legal links">
+                <a href="{{ config('job.legal_notice_url') }}" target="_blank">{{ __('home.legal_notice') }}</a>
+                <span class="app-footer__muted">•</span>
+                <a href="{{ config('job.privacy_policy_url') }}" target="_blank">{{ __('home.privacy_policy') }}</a>
+            </nav>
+        </div>
+    </footer>
+
+</html>

--- a/backend/resources/views/home.blade.php
+++ b/backend/resources/views/home.blade.php
@@ -8,6 +8,7 @@
     <title>{{ __('home.title') }}</title>
 
     <link rel="stylesheet" href="{{ asset('css/home.css') }}">
+    <script src="{{ asset('js/matomo-api.js') }}" defer></script>
 </head>
 
 <body>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,6 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', [HealthController::class, 'checkApi']);

--- a/frontend/src/app/pages/legal/page.ts
+++ b/frontend/src/app/pages/legal/page.ts
@@ -59,8 +59,7 @@ export class LegalPageComponent implements AfterViewInit, OnDestroy {
     // Nettoie le conteneur
     target.innerHTML = '';
 
-    const src =
-      `https://stats.manooweb.fr/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=${this.lang}&backgroundColor=FFFFFF&fontColor=000000&fontSize=12px&fontFamily=Arial&showIntro=1`;
+    const src = `https://stats.manooweb.fr/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=${this.lang}&backgroundColor=FFFFFF&fontColor=000000&fontSize=12px&fontFamily=Arial&showIntro=1`;
 
     // IMPORTANT: in SPA, script must be run again
     // So we remove any existing script with the same src before adding a new one

--- a/frontend/src/app/pages/legal/page.ts
+++ b/frontend/src/app/pages/legal/page.ts
@@ -10,6 +10,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { filter, Subscription } from 'rxjs';
+import { UiTextService } from '../../shared/i18n/ui-text.service';
 
 @Component({
   selector: 'app-legal-page',
@@ -23,8 +24,11 @@ export class LegalPageComponent implements AfterViewInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private sanitizer = inject(DomSanitizer);
+  private translate = inject(UiTextService);
 
   private sub?: Subscription;
+
+  private lang = this.translate.getLanguage();
 
   private html = computed(() => this.route.snapshot.data['html'] as string);
 
@@ -56,7 +60,7 @@ export class LegalPageComponent implements AfterViewInit, OnDestroy {
     target.innerHTML = '';
 
     const src =
-      'https://stats.manooweb.fr/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=auto&backgroundColor=FFFFFF&fontColor=000000&fontSize=12px&fontFamily=Arial&showIntro=1';
+      `https://stats.manooweb.fr/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=${this.lang}&backgroundColor=FFFFFF&fontColor=000000&fontSize=12px&fontFamily=Arial&showIntro=1`;
 
     // IMPORTANT: in SPA, script must be run again
     // So we remove any existing script with the same src before adding a new one


### PR DESCRIPTION
Closes https://github.com/manooweb/manooweb-site/issues/40

Add minimal API landing page and legal footer

- replace default Laravel welcome page
- add API health status indicator
- integrate frontend legal URLs via config
- add i18n support (fr default locale)
- reuse frontend CSS for visual consistency
- add Matomo tracking