### PR TITLE
Force https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ yarn-error.log*
 backend/vendor/
 backend/.env
 backend/.env.*
+backend/storage/
 backend/storage/*.key
 backend/storage/logs/
 backend/storage/framework/

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Health\DefaultHealthChecker;
+use Illuminate\Support\Facades\URL;
 use App\Health\HealthChecker;
 use Illuminate\Support\ServiceProvider;
 
@@ -21,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Event::listen(DiagnosingHealth::class, SimulateAppDown::class);
+        URL::forceScheme('https');
     }
 }

--- a/backend/storage/app/.gitignore
+++ b/backend/storage/app/.gitignore
@@ -1,4 +1,0 @@
-*
-!private/
-!public/
-!.gitignore

--- a/backend/storage/app/private/.gitignore
+++ b/backend/storage/app/private/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/backend/storage/app/public/.gitignore
+++ b/backend/storage/app/public/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
All is in the title.

The goal is to force SSL a simple way on all the internal URLs espacially when backend is behind a reverse proxy.